### PR TITLE
Java getter/setter are exported as JS property by default & new annotations added.

### DIFF
--- a/src/main/java/io/alicorn/v8/annotations/JSFunction.java
+++ b/src/main/java/io/alicorn/v8/annotations/JSFunction.java
@@ -3,7 +3,7 @@ package io.alicorn.v8.annotations;
 import java.lang.annotation.*;
 
 /**
- * An annotation that marks a Java method as JavaScript setter.
+ * An annotation that marks a Java method as JavaScript function.
  * When @JSNoAutoDetect is used on the class - it's required for exporting method to the JS runtime.
  *
  * @author Alex Trotsenko [alexey.trotsenko@gmail.com]
@@ -11,6 +11,6 @@ import java.lang.annotation.*;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface JSSetter {
+public @interface JSFunction {
     String value() default "";
 }

--- a/src/main/java/io/alicorn/v8/annotations/JSGetter.java
+++ b/src/main/java/io/alicorn/v8/annotations/JSGetter.java
@@ -4,6 +4,7 @@ import java.lang.annotation.*;
 
 /**
  * An annotation that marks a Java method as JavaScript getter.
+ * When @JSNoAutoDetect is used on the class - it's required for exporting method to the JS runtime.
  *
  * @author Alex Trotsenko [alexey.trotsenko@gmail.com]
  */

--- a/src/main/java/io/alicorn/v8/annotations/JSIgnore.java
+++ b/src/main/java/io/alicorn/v8/annotations/JSIgnore.java
@@ -3,14 +3,14 @@ package io.alicorn.v8.annotations;
 import java.lang.annotation.*;
 
 /**
- * An annotation that marks a Java method as JavaScript setter.
- * When @JSNoAutoDetect is used on the class - it's required for exporting method to the JS runtime.
+ * Using this annotation on the methods prevents it from being exported as function/property to JS runtime.
+ * When @JSNoAutoDetect is used on the class - this function does nothing.
  *
  * @author Alex Trotsenko [alexey.trotsenko@gmail.com]
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface JSSetter {
+public @interface JSIgnore {
     String value() default "";
 }

--- a/src/main/java/io/alicorn/v8/annotations/JSNoAutoDetect.java
+++ b/src/main/java/io/alicorn/v8/annotations/JSNoAutoDetect.java
@@ -1,0 +1,16 @@
+package io.alicorn.v8.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Mark the class, where only method with @JSGetter/@JSSetter/@JSFunction annotations will be exported to js.
+ *
+ * @author Alex Trotsenko [alexey.trotsenko@gmail.com]
+ *
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface JSNoAutoDetect {
+    String value() default "";
+}

--- a/src/main/java/io/alicorn/v8/annotations/JSStaticFunction.java
+++ b/src/main/java/io/alicorn/v8/annotations/JSStaticFunction.java
@@ -3,7 +3,7 @@ package io.alicorn.v8.annotations;
 import java.lang.annotation.*;
 
 /**
- * An annotation that marks a Java method as JavaScript setter.
+ * An annotation that marks a Java static method as JavaScript function.
  * When @JSNoAutoDetect is used on the class - it's required for exporting method to the JS runtime.
  *
  * @author Alex Trotsenko [alexey.trotsenko@gmail.com]
@@ -11,6 +11,6 @@ import java.lang.annotation.*;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface JSSetter {
+public @interface JSStaticFunction {
     String value() default "";
 }


### PR DESCRIPTION
Briefly this commit is implementations of what was discussed at https://github.com/alicorn-systems/v8-adapter/pull/2#issuecomment-358252745

1. Java getter/setter are exported as JS property by default
2. When @JSGetter/@JSSetter is used on Non-getter/setter this results in exporting it as JS property regardles of naming Java convetion.
3. @JSFunction & @JSStaticFunction added for explicitly marking instance/static methods as exported to JS runtime.
4. @JSNoAutoDetect added for marking all methods & getter/setter-s of the class as not imported (unless these methods explicitly annotated with  @JSGetter/@JSSetter/@JSFunction/@JSStaticFunction)
5. Tests for new functionality was added & existing tests were modified.
6. Change Assert.assertFalse(v8.executeBooleanScript(...)) to Assert.assertEquals(false, v8.executeScript(...) in order to see clean test output, but not thrown exception, when return value is not boolean, e.g. undefined.