### PR TITLE
Added ability to read data from V8 JS objec

### DIFF
--- a/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
+++ b/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
@@ -1,6 +1,7 @@
 package io.alicorn.v8;
 
 import com.eclipsesource.v8.*;
+import com.eclipsesource.v8.utils.V8ObjectUtils;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.*;
@@ -471,6 +472,10 @@ public final class V8JavaObjectUtils {
                             throw new IllegalArgumentException(
                                     "Argument is Java type but does not match signature for this method.");
                         }
+                    } else if (Map.class == javaArgumentType || Object.class == javaArgumentType) {
+                        return V8ObjectUtils.toMap(argumentObject);
+                    } else if (V8Object.class == javaArgumentType) {
+                        return argumentObject.twin();
                     } else {
                         cache.removeGarbageCollectedJavaObjects();
                         throw new IllegalArgumentException(

--- a/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
+++ b/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
@@ -455,15 +455,17 @@ public final class V8JavaObjectUtils {
                 }
             } else if (argument instanceof V8Object) {
                 try {
-                    //Attempt to retrieve a Java object handle.
-                    String javaHandle = (String) ((V8Object) argument).get(JAVA_OBJECT_HANDLE_ID);
-                    Object javaObject = cache.identifierToJavaObjectMap.get(javaHandle).get();
+                    final V8Object argumentObject = (V8Object) argument;
 
-                    if (javaObject != null) {
+                    if (argumentObject.contains(JAVA_OBJECT_HANDLE_ID)) {
+                        //Attempt to retrieve a Java object handle.
+                        String javaHandle = (String) argumentObject.get(JAVA_OBJECT_HANDLE_ID);
+                        Object javaObject = cache.identifierToJavaObjectMap.get(javaHandle).get();
+
                         if (javaArgumentType.isAssignableFrom(javaObject.getClass())) {
                             // Check if it's intercepted.
                             cache.cachedV8JavaClasses.get(javaObject.getClass()).readInjectedInterceptor(
-                                    (V8Object) argument);
+                                    argumentObject);
                             return javaObject;
                         } else {
                             throw new IllegalArgumentException(
@@ -476,10 +478,10 @@ public final class V8JavaObjectUtils {
                     }
                 } catch (NullPointerException e) {
                     throw new IllegalArgumentException(
-                            "Argument has invalid Java object handle or object referenced by handle has aged out.");
+                            "Argument has invalid Java object handle or object referenced by handle has aged out.", e);
                 } catch (ClassCastException e) {
                     throw new IllegalArgumentException(
-                            "Complex objects can only be passed to Java if they represent Java objects.");
+                            "Complex objects can only be passed to Java if they represent Java objects.", e);
                 }
             } else {
                 //TODO: Add support for arrays.


### PR DESCRIPTION
`v8-adapter` lib now is able to "translate"  objects, created in V8 runtime to Java's Map or J2V8's V8Object when it's declared as the argument's type in the method of the injected class.