### PR TITLE
Added "spreading" of java functional interface var-args arguments to JS function args

### DIFF
--- a/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
+++ b/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
@@ -98,7 +98,16 @@ public final class V8JavaObjectUtils {
 
         @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             try {
-                V8Array v8Args = translateJavaArgumentsToJavascript(args, V8JavaObjectUtils.getRuntimeSarcastically(receiver), cache);
+                final boolean varArgsOnlyMethod = method.isVarArgs() && method.getParameterTypes().length == 1;
+                final Object[] javaArgs;
+                if (!varArgsOnlyMethod) {
+                    javaArgs = args;
+                } else {
+                    //XXX: also consider "spreading" of var-args if there are another arguments before as for JS->Java case
+                    javaArgs = (Object[]) args[0];
+                }
+
+                V8Array v8Args = translateJavaArgumentsToJavascript(javaArgs, V8JavaObjectUtils.getRuntimeSarcastically(receiver), cache);
                 Object obj = function.call(receiver, v8Args);
                 if (!v8Args.isReleased()) {
                     v8Args.release();

--- a/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
+++ b/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
@@ -24,6 +24,10 @@ public class V8JavaAdapterTest {
         int doInterface(int args);
     }
 
+    private interface CallBack {
+        Object call(Object... args);
+    }
+
     private static final class Foo {
         public int i;
         public Foo(int i) { this.i = i; }
@@ -33,6 +37,7 @@ public class V8JavaAdapterTest {
         public void add(Foo foo) { this.i += foo.i; }
         public void add(Bar bar) { this.i = bar.doInterface(this.i); }
         public void addBaz(Baz baz) { this.i = baz.doFooInterface(this).getI(); }
+        public Object invokeCallBack(CallBack callBack, Object... args) {return callBack.call(args); }
         public String doString(String s) { return s; }
         public int getI() { return i; }
         public Foo copy() { return new Foo(i); }
@@ -384,6 +389,19 @@ public class V8JavaAdapterTest {
     public void shouldHandleFunctionalArguments() {
         Assert.assertEquals(1500, v8.executeIntegerScript("var x = new Foo(3000); x.add(function(i) { return i / 2; }); x.getI();"));
         Assert.assertEquals(1500, v8.executeIntegerScript("var x = new Foo(3000); x.addBaz(function(foo) { return new Foo(foo.getI() / 2); }); x.getI();"));
+    }
+
+    @Test
+    public void shouldHandleFunctionalArgumentsWithVarArg() {
+        final int one = 1;
+        final int two = 2;
+        final int three = 3;
+        final int sum = one + two + three;
+
+        Assert.assertEquals(sum, v8.executeScript("var x = new Foo(0); var sumCallBack = function(arg1, arg2, arg3) { return arg1 + arg2 + arg3; }; x.invokeCallBack(sumCallBack, " + one + ", " + two + ", " + three + ");"));
+
+        final int four = 4;
+        Assert.assertEquals(sum, v8.executeScript("var x = new Foo(0); var sumCallBack = function(arg1, arg2, arg3) { return arg1 + arg2 + arg3; }; x.invokeCallBack(sumCallBack, " + one + ", " + two + ", " + three + ", " + four + ");"));
     }
 
     @Test


### PR DESCRIPTION
(at invocation of FunctionInterface with single var-args)

This way JS see them as normal arguments, but not single argument with an array, containing initial var-arg params.
(complements var-args behaviour during translation from JS to Java).

E.g. calling  `callBack.call(1, 2, 3)` from Java will results in three arguments in JS - `1`,` 2`,` 3`, but not three arguments like this: `[1, 2, 3]`, `undefined` , `undefined`.

Here Function interface is following:
```.Java
    private interface CallBack {
        Object call(Object... args);
    }
```