### PR TITLE
JS Object/JS array api for inject/returned Java Map/List

### DIFF
--- a/src/main/java/io/alicorn/v8/V8JavaAdapter.java
+++ b/src/main/java/io/alicorn/v8/V8JavaAdapter.java
@@ -148,8 +148,10 @@ public final class V8JavaAdapter {
         //Calculate V8-friendly full class names.
         String v8FriendlyClassname = classy.getName().replaceAll("\\.+", "_");
 
+        final V8 v8 = V8JavaObjectUtils.getRuntimeSarcastically(rootObject);
+
         // Determine cache to use.
-        V8JavaCache cache = getCacheForRuntime(rootObject.getRuntime());
+        V8JavaCache cache = getCacheForRuntime(v8);
 
         //Register the class proxy.
         V8JavaClassProxy proxy;
@@ -178,7 +180,8 @@ public final class V8JavaAdapter {
             script.append("\n};");
 
             //Evaluate the script to create a new constructor function.
-            V8JavaObjectUtils.getRuntimeSarcastically(rootObject).executeVoidScript(script.toString());
+
+            v8.executeVoidScript(script.toString());
 
             //Build up static methods if needed.
             if (proxy.getInterceptor() == null) {

--- a/src/main/java/io/alicorn/v8/V8JavaClassProxy.java
+++ b/src/main/java/io/alicorn/v8/V8JavaClassProxy.java
@@ -384,9 +384,10 @@ final class V8JavaClassProxy implements JavaCallback {
 
         // Register properties (getters and setters).
         for (String methodName : gettersAndSetters) {
+            final V8 v8 = V8JavaObjectUtils.getRuntimeSarcastically(jsObject);
 
             // Create a new JS object.
-            V8Object methodProperty = new V8Object(jsObject.getRuntime());
+            V8Object methodProperty = new V8Object(v8);
 
             // Insert getter (if available).
             if (gettersMap.containsKey(methodName)) {
@@ -399,7 +400,7 @@ final class V8JavaClassProxy implements JavaCallback {
             }
 
             // Define property on JS object.
-            V8Object object = V8JavaObjectUtils.getRuntimeSarcastically(jsObject).getObject("Object");
+            V8Object object = v8.getObject("Object");
             V8Object ret = (V8Object) object.executeJSFunction("defineProperty", jsObject, methodName, methodProperty);
 
             // Release garbage.

--- a/src/main/java/io/alicorn/v8/utils/NamingHelper.java
+++ b/src/main/java/io/alicorn/v8/utils/NamingHelper.java
@@ -1,0 +1,29 @@
+package io.alicorn.v8.utils;
+
+import java.util.UUID;
+
+/**
+ * Contains utility logic related to naming convention used in the project.
+ */
+public class NamingHelper {
+    public static NamingHelper INSTANCE = new NamingHelper();
+
+    private NamingHelper() {
+    }
+
+    public String randomVarName() {
+        return "TEMP" + randomId();
+    }
+
+    public String randomInstanceAddress() {
+        return "OHID" + randomId();
+    }
+
+    public String randomInterceptorAddress() {
+        return "CICHID" + randomId();
+    }
+
+    private String randomId() {
+        return UUID.randomUUID().toString().replaceAll("-", "");
+    }
+}

--- a/src/main/java/io/alicorn/v8/utils/V8Helper.java
+++ b/src/main/java/io/alicorn/v8/utils/V8Helper.java
@@ -1,0 +1,32 @@
+package io.alicorn.v8.utils;
+
+import com.eclipsesource.v8.V8;
+import com.eclipsesource.v8.V8ScriptExecutionException;
+
+public class V8Helper {
+    public static V8Helper INSTANCE = new V8Helper();
+    private Boolean supportsProxy = null;
+
+    private V8Helper() {
+    }
+
+    /**
+     * @return whether Proxy is supported as a language feature. E.g. current v8 version is at least 4.9.
+     */
+    public boolean isSupportsProxy(V8 v8) {
+        if (supportsProxy == null) {
+            try {
+                //instead V8.getV8Version() can be compared >= 4.9, but executing empty Proxy is easy and more reliable.
+                v8.executeVoidScript("new Proxy({},{})");
+                supportsProxy = true;
+            } catch (V8ScriptExecutionException e) {
+                System.out.println("[warning] Proxy is not supported:"
+                        + " features like 'java map to js object' convection are not enabled."
+                        + " Required V8 4.9, but current version is " + V8.getV8Version());
+                supportsProxy = false;
+            }
+        }
+
+        return supportsProxy;
+    }
+}

--- a/src/main/java/io/alicorn/v8/utils/V8Helper.java
+++ b/src/main/java/io/alicorn/v8/utils/V8Helper.java
@@ -29,4 +29,6 @@ public class V8Helper {
 
         return supportsProxy;
     }
+
+    //check if V8JavaObjectUtils.getRuntimeSarcastically() is still needed and if so - move the method here for clarity.
 }

--- a/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
+++ b/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
@@ -6,6 +6,7 @@ import io.alicorn.v8.annotations.JSDisableMethodAutodetect;
 import io.alicorn.v8.annotations.JSGetter;
 import io.alicorn.v8.annotations.JSSetter;
 import io.alicorn.v8.annotations.JSStaticFunction;
+import io.alicorn.v8.utils.V8Helper;
 import org.hamcrest.core.IsInstanceOf;
 import org.hamcrest.core.StringContains;
 import org.junit.*;
@@ -757,4 +758,38 @@ public class V8JavaAdapterTest {
         Assert.assertEquals(null, v8.executeScript("var x = new JsNullReader(); var y = x.readAndGetInt(); y;"));
     }
 
+    @Test
+    public void shouldInjectMapAsMapWithJsObjectApi() {
+        final HashMap<String, Object> testMap = new HashMap<String, Object>();
+        final String key = "myKey";
+        final String value = "myValue";
+        testMap.put(key, value);
+
+        V8JavaAdapter.injectObject("testMap", testMap, v8);
+
+        Assert.assertEquals(value, v8.executeScript("testMap.get( '" + key + "' )"));
+
+        Assume.assumeTrue(V8Helper.INSTANCE.isSupportsProxy(v8));
+        Assert.assertEquals(value, v8.executeScript("testMap[ '" + key + "' ]"));
+        Assert.assertEquals(value, v8.executeScript("testMap." + key));
+    }
+
+    @Test
+    public void shouldInjectListAsListWithJsArrayApi() {
+        Assume.assumeTrue(V8Helper.INSTANCE.isSupportsProxy(v8));
+
+        final List<String> testList = new ArrayList<String>();
+        final String first = "foo";
+        final String second = "bar";
+        testList.add(first);
+        testList.add(second);
+
+        V8JavaAdapter.injectObject("testList", testList, v8);
+
+
+        final int indexOfSecond = testList.indexOf(second);
+        Assert.assertEquals(second, v8.executeScript("testList.get(" + indexOfSecond + ")"));
+        Assume.assumeTrue(V8Helper.INSTANCE.isSupportsProxy(v8));
+        Assert.assertEquals(second, v8.executeScript("testList[ '" + indexOfSecond + "' ]"));
+    }
 }


### PR DESCRIPTION
For compatibility with existing `v8-adapter` behaviour: maps and list are injected as maps and list (e.g. methods are available in JS runtime), but JS object/JS array api is added using `Proxy`.

For backward compatibility with older J2V8 versions: this api is added conditionally if `Proxy` is available in V8. E.g. if it's at least [4.9](https://v8project.blogspot.ch/2016/01/v8-release-49.html).

#11