### PR TITLE
Fix issue where Java methods would be passed null parameters if the J…

### DIFF
--- a/src/main/java/io/alicorn/v8/V8JavaClassProxy.java
+++ b/src/main/java/io/alicorn/v8/V8JavaClassProxy.java
@@ -369,9 +369,6 @@ final class V8JavaClassProxy implements JavaCallback {
     /**
      * Injects getter and setter properties into the given JS object.
      *
-     * The getters and setters that are injected are based on prior invocations of
-     * {@link #registerGettersAndSetters(V8JavaInstanceMethodProxy)}.
-     *
      * @param javaObject Java object which is "injected" in JS. Required for
      *                   re-direction of the property access to it's getters/setters.
      * @param jsObject JS object created for dispatching calls from JS runtime to
@@ -448,11 +445,11 @@ final class V8JavaClassProxy implements JavaCallback {
 //                }
 //            }, "$release");
         } catch (InstantiationException e) {
-            throw new IllegalArgumentException("Constructor received invalid arguments!");
+            throw new IllegalArgumentException("Constructor received invalid arguments!", e);
         } catch (IllegalAccessException e) {
-            throw new IllegalArgumentException("Constructor received invalid arguments!");
+            throw new IllegalArgumentException("Constructor received invalid arguments!", e);
         } catch (InvocationTargetException e) {
-            throw new IllegalArgumentException("Constructor received invalid arguments!");
+            throw new IllegalArgumentException("Constructor received invalid arguments!", e);
         }
 
         return null;

--- a/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
+++ b/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
@@ -681,8 +681,9 @@ public final class V8JavaObjectUtils {
 
             return returnedArgumentValues;
 
-        // Typical handling.
-        } else if (javaArgumentTypes.length >= javascriptArguments.length()) {
+        // Typical handling. Argument lengths must match exactly; Java does
+        // not consistently support random null values being passed in to core libraries.
+        } else if (javaArgumentTypes.length == javascriptArguments.length()) {
             Object[] returnedArgumentValues = new Object[javaArgumentTypes.length];
 
             for (int i = 0; i < javascriptArguments.length(); i++) {
@@ -698,16 +699,11 @@ public final class V8JavaObjectUtils {
                 }
             }
 
-            //all the params in the JS are optional and undefined is passed as
-            for (int i = javascriptArguments.length(); i < javaArgumentTypes.length; i++) {
-                returnedArgumentValues[i] = nullOrThrowOnPrimitive(javaArgumentTypes[i]);
-            }
-
             return returnedArgumentValues;
         } else {
             throw new IllegalArgumentException(
-                    "Method arguments size and passed arguments size do not match.  " +
-                            "Expected " + javaArgumentTypes.length + ", but got " + javascriptArguments.length());
+                "Method arguments size and passed arguments size do not match. " +
+                "Expected " + javaArgumentTypes.length + ", but got " + javascriptArguments.length());
         }
     }
 }

--- a/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
+++ b/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
@@ -11,6 +11,7 @@ import org.hamcrest.core.StringContains;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 
+import java.io.File;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -740,15 +741,6 @@ public class V8JavaAdapterTest {
     }
 
     @Test
-    public void shouldReadJsLessArgsAsNull() {
-        V8JavaAdapter.injectClass(JsNullReader.class, v8);
-
-        Assert.assertEquals(null, v8.executeScript("var x = new JsNullReader(); var y = x.readAndGetInteger(); y;"));
-        Assert.assertEquals(null, v8.executeScript("var x = new JsNullReader(); var y = x.readAndGetJavaClass(); y;"));
-        Assert.assertEquals(null, v8.executeScript("var x = new JsNullReader(); var y = x.readAndGetJavaFunctionalInterface(); y;"));
-    }
-
-    @Test
     public void shouldThrowIllArgExWhenJsLessArgToPrimitive() {
         V8JavaAdapter.injectClass(JsNullReader.class, v8);
 
@@ -757,4 +749,9 @@ public class V8JavaAdapterTest {
         Assert.assertEquals(null, v8.executeScript("var x = new JsNullReader(); var y = x.readAndGetInt(); y;"));
     }
 
+    @Test
+    public void shouldChooseCorrectConstructorAndNotPassNulls() {
+        V8JavaAdapter.injectClass(File.class, v8);
+        v8.executeVoidScript("var f = new File(\"test.txt\");");
+    }
 }


### PR DESCRIPTION
…S parameters list did not match.

This addresses #14. @AlexTrotsenko does this seem ok to you? I think this behavior was introduced by a modification made by an earlier PR, but for translating to Java we really cannot support automatic null fields; some Java APIs see null inputs as an error, and automatically inserting nulls causes confusion for users of the API.