### PR TITLE
Added ability to read JS Functions without specifying exact java interface.

### DIFF
--- a/src/main/java/io/alicorn/v8/JsBasedCallBack.java
+++ b/src/main/java/io/alicorn/v8/JsBasedCallBack.java
@@ -1,0 +1,9 @@
+package io.alicorn.v8;
+
+/**
+ * If gc v8 executor is specified and Object is found as target type for "JS to Java" transformation -
+ * proxy based on this class is used instead.
+ */
+public interface JsBasedCallBack {
+    Object call(Object... args);
+}

--- a/src/main/java/io/alicorn/v8/JsBasedCallBack.java
+++ b/src/main/java/io/alicorn/v8/JsBasedCallBack.java
@@ -1,9 +1,11 @@
 package io.alicorn.v8;
 
+import com.eclipsesource.v8.Releasable;
+
 /**
  * If gc v8 executor is specified and Object is found as target type for "JS to Java" transformation -
  * proxy based on this class is used instead.
  */
-public interface JsBasedCallBack {
+public interface JsBasedCallBack extends Releasable {
     Object call(Object... args);
 }

--- a/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
+++ b/src/main/java/io/alicorn/v8/V8JavaObjectUtils.java
@@ -107,8 +107,11 @@ public final class V8JavaObjectUtils {
           }
         }
 
-        @Override
-        public void release() {
+        @Override public void release() {
+            /*
+             *  Note: check for isReleased() is required:
+             *  otherwise .remove() invokes equals on v8 object, which throws if object is released.
+             */
             if (!receiver.isReleased()) {
               v8Resources.remove(receiver);
 
@@ -403,13 +406,14 @@ public final class V8JavaObjectUtils {
         // Remove resources across runtime.
         for (Iterator<V8Value> iterator = v8Resources.iterator(); iterator.hasNext();) {
             V8Value resource = iterator.next();
+            iterator.remove();
+
             if (resource != null) {
                 if (V8JavaObjectUtils.getRuntimeSarcastically(resource) == v8) {
                     resource.release();
                     released++;
                 }
             }
-            iterator.remove();
         }
 
         // Free any garbage collected classes.

--- a/src/main/java/io/alicorn/v8/annotations/callback/JSListener.java
+++ b/src/main/java/io/alicorn/v8/annotations/callback/JSListener.java
@@ -1,0 +1,19 @@
+package io.alicorn.v8.annotations.callback;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a Java functional interface as a Javascript Listener, but not as call-back.
+ *
+ * This annotation is required for retaining underlying V8 function after 1st call of related JS.
+ * Should be used if Js Function is expected to be called multiple times in listener manner
+ *  (comparing to call-back function, which is expected to be called only once).
+ *
+ * @author Alex Trotsenko [alexey.trotsenko@gmail.com]
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface JSListener {
+    String value() default "";
+}

--- a/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
+++ b/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
@@ -14,6 +14,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.util.*;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class V8JavaAdapterTest {
@@ -300,6 +301,18 @@ public class V8JavaAdapterTest {
             v8Args.release();
             callBack.release();
         }
+
+        public void sumAndAndTryToNotify(int left, int right, Object possibleCallBack) {
+            final int sum = left + right;
+            final List<Integer> callBackArg = Collections.singletonList(sum);
+
+            if (!(possibleCallBack instanceof JsBasedCallBack)) {
+              throw new IllegalArgumentException("Can't call object, which is not JsBasedCallBack, but " + possibleCallBack);
+            }
+
+            final JsBasedCallBack callBack = (JsBasedCallBack) possibleCallBack;
+            callBack.call(sum);
+        }
     }
 
     private static final class NativeJsArrayReader {
@@ -463,7 +476,6 @@ public class V8JavaAdapterTest {
 
         //should throw here
         final Object actualResult = v8.executeScript("var x = new Foo(0); var sumCallBack = function(arg1, arg2, arg3) { return arg1 + arg2 + arg3; }; x.invokeCallBackTwice(sumCallBack, " + one + ", " + two + ", " + three + ");");
-        throw new IllegalStateException("Now Exception is thrown!");
     }
 
     @Test
@@ -794,6 +806,50 @@ public class V8JavaAdapterTest {
         final int sum = one + two;
 
         v8.executeScript("var x = new NativeJsFunctionReader(); var y = x.sumAndNotify(" + one + ", " + two + ", function(sum) { sumContainer.set(sum); } ); y;");
+
+        Assert.assertEquals(sum, sumContainer.get());
+    }
+
+    @Test
+    public void shouldReadFunctionAsJavaObject() {
+        V8JavaAdapter.injectClass(NativeJsFunctionReader.class, v8);
+
+        final AtomicInteger sumContainer = new AtomicInteger();
+        V8JavaAdapter.injectObject("sumContainer", sumContainer, v8);
+
+        final int one = 1;
+        final int two = 2;
+        final int sum = one + two;
+
+        final Executor executorStub = new Executor() {
+            @Override public void execute(Runnable command) {
+                //stub, which does nothing
+            }
+        };
+
+        V8JavaObjectUtils.setGcExecutor(executorStub);
+        v8.executeScript("var x = new NativeJsFunctionReader(); var y = x.sumAndAndTryToNotify(" + one + ", " + two + ", function(sum) { sumContainer.set(sum); } ); y;");
+        V8JavaObjectUtils.removeGcExecutor();
+
+        Assert.assertEquals(sum, sumContainer.get());
+    }
+
+
+    @Test
+    public void shouldNotReadFunctionAsJavaObjectWithoutGcExecutor() {
+        V8JavaAdapter.injectClass(NativeJsFunctionReader.class, v8);
+
+        final AtomicInteger sumContainer = new AtomicInteger();
+        V8JavaAdapter.injectObject("sumContainer", sumContainer, v8);
+
+        final int one = 1;
+        final int two = 2;
+        final int sum = one + two;
+
+        thrown.expect(V8ScriptExecutionException.class);
+        thrown.expectMessage(StringContains.containsString("No signature exists for sumAndAndTryToNotify"));
+
+        v8.executeScript("var x = new NativeJsFunctionReader(); var y = x.sumAndAndTryToNotify(" + one + ", " + two + ", function(sum) { sumContainer.set(sum); } ); y;");
 
         Assert.assertEquals(sum, sumContainer.get());
     }


### PR DESCRIPTION
This PR is related to #11 but can be implemented only now after [PR #26](https://github.com/alicorn-systems/v8-adapter/pull/26) for issues #24.

Ability to read `V8Function` as default interface `JsBasedCallBack` without specifying it's exact type _(but `java.lang.Object`)_ compliments ability to read `V8Object` as `Map` and `V8Array` as `List` in the similar cases.

This could be useful if:
* type of data coming from JS is unknown or could be one or another. 
* for the cases when `V8Object` contains `V8Function` inside. Then it could be read as `Map` without worries of throwing an error if function is present.

It's should not cause any memory issues because _"Js to default Java interface"_ behaviour is enabled only if executor for GC/release on V8 thread is provided.

Also `JsBasedCallBack` implementation is more efficient comparing to another "JS to Java interface" callback because it's not using `Proxy`, but extends common class - `JsCallBackAdapter`.