### PR TITLE
#11 Added ability to customise result of injection java object into JS using V8JavaClassInterceptor

### DIFF
--- a/src/main/java/io/alicorn/v8/V8JavaClassInterceptor.java
+++ b/src/main/java/io/alicorn/v8/V8JavaClassInterceptor.java
@@ -10,6 +10,17 @@ package io.alicorn.v8;
 public interface V8JavaClassInterceptor<T> {
 
     /**
+     * @return if not null - result of this method will be return as result of object injection in JS.
+     * Actual java object will be passed for ability to handle the incoming data.
+     *
+     * It does not change behaviour of newly created object in JS on purpose (using new ClassName())
+     *  because newly created object does not have state yet.
+     *
+     *  It's safe to return both V8 or Java object from this method.
+     */
+    Object objectInjectorOverride(T object);
+
+    /**
      * Returns the body of the JS constructor function that this
      * interceptor works with.
      *

--- a/src/main/java/io/alicorn/v8/V8Runtime.java
+++ b/src/main/java/io/alicorn/v8/V8Runtime.java
@@ -2,6 +2,7 @@ package io.alicorn.v8;
 
 import com.eclipsesource.v8.V8;
 import com.eclipsesource.v8.V8Object;
+import com.eclipsesource.v8.V8Value;
 
 import java.util.*;
 
@@ -63,12 +64,30 @@ public class V8Runtime {
 
         // Attach interceptor.
         if (proxy.getInterceptor() != null) {
-            script.append(proxy.getInterceptor().getConstructorScriptBody());
+            //override injection if any
+            final Object injectionOverride = proxy.getInterceptor().objectInjectorOverride(object);
+            if (injectionOverride == null) {
+                script.append(proxy.getInterceptor().getConstructorScriptBody());
+            } else {
+                final V8Value convertedToV8JavaObject;
+                if (injectionOverride instanceof V8Object) {
+                    convertedToV8JavaObject = (V8Value) injectionOverride;
+                } else {
+                    convertedToV8JavaObject = (V8Value) V8JavaObjectUtils.translateJavaArgumentToJavascript(injectionOverride, v8, cache);
+                }
+
+                String javaObjectName = name + "java";
+                v8.add(javaObjectName, convertedToV8JavaObject);
+                convertedToV8JavaObject.release();
+
+                //return injected javaObject and clear reference to this variable
+                script.append("try { return ").append(javaObjectName).append("; } finally { " + javaObjectName + " = undefined; }");
+            }
         }
 
         script.append("\n}; ").append(name).append(";");
 
-        V8Object other = V8JavaObjectUtils.getRuntimeSarcastically(rootObject).executeObjectScript(script.toString());
+        V8Object other = v8.executeObjectScript(script.toString());
         String id = proxy.attachJavaObjectToJsObject(object, other);
         other.release();
         return id;

--- a/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
+++ b/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
@@ -14,6 +14,7 @@ import org.junit.rules.ExpectedException;
 import java.io.File;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class V8JavaAdapterTest {
 //Setup classes////////////////////////////////////////////////////////////////
@@ -165,6 +166,8 @@ public class V8JavaAdapterTest {
 
     private static final class FooInterceptor implements V8JavaClassInterceptor<InterceptableFoo> {
 
+        @Override public Object objectInjectorOverride(InterceptableFoo object) { return null; }
+
         @Override public String getConstructorScriptBody() {
             return "var i = 0;\n" +
                     "this.getI = function() { return i; };\n" +
@@ -225,6 +228,18 @@ public class V8JavaAdapterTest {
 
         public void setMap(Map<String, ?> map) {
             this.map = map;
+        }
+    }
+
+    private static final class RawListHolder {
+        List<?> list;
+
+        public List<?> getMap() {
+            return list;
+        }
+
+        public void setList(List<?> list) {
+            this.list = list;
         }
     }
 
@@ -753,5 +768,74 @@ public class V8JavaAdapterTest {
     public void shouldChooseCorrectConstructorAndNotPassNulls() {
         V8JavaAdapter.injectClass(File.class, v8);
         v8.executeVoidScript("var f = new File(\"test.txt\");");
+    }
+
+    @Test
+    public void shouldCustomizeJavaToJSTransformation() {
+        final V8JavaClassInterceptor interceptor = new V8JavaClassInterceptor<Map>() {
+            @Override
+            public Object objectInjectorOverride(Map object) {
+                return V8ObjectUtils.toV8Object(v8, object);
+            }
+
+            @Override public String getConstructorScriptBody() { return null; }
+            @Override public void onInject(V8JavaClassInterceptorContext context, Map object) { }
+            @Override public void onExtract(V8JavaClassInterceptorContext context, Map object) { }
+        };
+
+        final V8JavaClassInterceptor listInterceptor = new V8JavaClassInterceptor<List>() {
+            @Override
+            public Object objectInjectorOverride(List object) {
+                return V8ObjectUtils.toV8Array(v8, object);
+            }
+
+            @Override public String getConstructorScriptBody() { return null; }
+            @Override public void onInject(V8JavaClassInterceptorContext context, List object) { }
+            @Override public void onExtract(V8JavaClassInterceptorContext context, List object) { }
+        };
+
+        V8JavaAdapter.injectClass(HashMap.class, interceptor, v8);
+        V8JavaAdapter.injectClass(ArrayList.class, listInterceptor, v8);
+
+        final Map<String, Object> mapToExportToJs = new HashMap<String, Object>();
+
+        final String stringKey = "stringKey";
+        final String stringValue = "stringValue";
+        mapToExportToJs.put(stringKey, stringValue);
+
+        final List<String> listToExportToJs = new ArrayList<String>();
+        final String list1stElement = "myElement";
+        listToExportToJs.add(list1stElement);
+
+        final String listKey = "listKey";
+        mapToExportToJs.put(listKey, listToExportToJs);
+
+        final RawMapHolder mapProvider = new RawMapHolder();
+        mapProvider.setMap(mapToExportToJs);
+
+        final String mapProviderJsName = "mapProvider";
+        V8JavaAdapter.injectObject(mapProviderJsName, mapProvider, v8);
+
+        final String holderJsName = "holder";
+        AtomicReference<Object> holder = new AtomicReference<Object>();
+        V8JavaAdapter.injectObject(holderJsName, holder, v8);
+
+
+        //check customized transformation behaviour
+        v8.executeVoidScript("var exportedMap = mapProvider.getMap(); var value = exportedMap['" + stringKey + "']; holder.set(value)");
+        Assert.assertEquals(stringValue, holder.get());
+
+        v8.executeVoidScript("var exportedMap = mapProvider.getMap(); var value = exportedMap['" + listKey + "'][0]; holder.set(value)");
+        Assert.assertEquals(list1stElement, holder.get());
+
+        final RawListHolder listProvider = new RawListHolder();
+        listProvider.setList(listToExportToJs);
+
+        final String listProviderJsName = "listProvider";
+        V8JavaAdapter.injectObject(listProviderJsName, listProvider, v8);
+
+
+        v8.executeVoidScript("var exportedList = listProvider.getMap(); var value = exportedList[0]; holder.set(value)");
+        Assert.assertEquals(list1stElement, holder.get());
     }
 }


### PR DESCRIPTION
It's need for conversions like `java List` to `JS array` or ` Java Map` to `JS Object`, etc.

It's changes only behaviour of injected java objects (as it _has_ some _state_ needed by JS), but not creation of such objects in JS by `new HashMap()` calls.

Notes on implementation:
- Currently `.onInject()` is called when JS object is already created. Thus it's **not** possible to create JS array instead of v8 object when Java list is used in conversion.

* It might be possible to use `.getConstructorScriptBody()` in following way:

```.Java
final V8JavaClassInterceptor interceptor = new V8JavaClassInterceptor<Map>() {
	@Override 
	public String getConstructorScriptBody(!!!javaObject!!!) {
        if (javaObject == null) return "";

	final V8Object convertedToV8JavaObject = V8ObjectUtils.toV8Object(v8, javaObject);
	    String javaObjectName = "javaObjectRandomeName";
	    v8.add(javaObjectName, convertedToV8JavaObject);
	    convertedToV8JavaObject.release();

	    //return injected javaObject and clear reference to this variable
	    script.append("try { return ").append(javaObjectName).append("; } finally { " + javaObjectName + " = undefined; }");
	}
    @Override public void onInject(V8JavaClassInterceptorContext context, Map object) { }
    @Override public void onExtract(V8JavaClassInterceptorContext context, Map object) { }
};
```

This anyway would require changing signature of `V8JavaClassInterceptor` by addig javaObject as incoming argument. Thus introducing new dedicated method looks like cleaner approach for me, but feel free to change it if you don't find it so.

* Also since now default methods are supported by Android __(using de-sugaring)__ - it might be possible to make this method default. Thus not changes to existing implementations of 
` V8JavaClassInterceptor`.