### PR TITLE
#11 Fixes bug when v8 object was read with old content in Java 

### DIFF
--- a/src/main/java/io/alicorn/v8/V8Runtime.java
+++ b/src/main/java/io/alicorn/v8/V8Runtime.java
@@ -62,11 +62,13 @@ public class V8Runtime {
         StringBuilder script = new StringBuilder();
         script.append("var ").append(name).append(" = new function() {");
 
+        boolean objectInjectionOverridden = false;
         // Attach interceptor.
         if (proxy.getInterceptor() != null) {
             //override injection if any
             final Object injectionOverride = proxy.getInterceptor().objectInjectorOverride(object);
-            if (injectionOverride == null) {
+            objectInjectionOverridden = injectionOverride != null;
+            if (!objectInjectionOverridden) {
                 script.append(proxy.getInterceptor().getConstructorScriptBody());
             } else {
                 final V8Value convertedToV8JavaObject;
@@ -88,7 +90,19 @@ public class V8Runtime {
         script.append("\n}; ").append(name).append(";");
 
         V8Object other = v8.executeObjectScript(script.toString());
-        String id = proxy.attachJavaObjectToJsObject(object, other);
+
+        String id;
+        if (!objectInjectionOverridden) {
+            id = proxy.attachJavaObjectToJsObject(object, other);
+        } else {
+            /**
+             * There is no need to attach v8 object, which is result of overridden java object injection:
+             *  - it's either completely self-contained new V8 object
+             *  - or if it's normal java object - it's already attached in .translateJavaArgumentToJavascript() method.
+             */
+            id = name;
+        }
+
         other.release();
         return id;
     }

--- a/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
+++ b/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
@@ -821,7 +821,6 @@ public class V8JavaAdapterTest {
         V8JavaAdapter.injectObject(holderJsName, holder, v8);
 
 
-        //check customized transformation behaviour
         v8.executeVoidScript("var exportedMap = mapProvider.getMap(); var value = exportedMap['" + stringKey + "']; holder.set(value)");
         Assert.assertEquals(stringValue, holder.get());
 
@@ -837,5 +836,45 @@ public class V8JavaAdapterTest {
 
         v8.executeVoidScript("var exportedList = listProvider.getMap(); var value = exportedList[0]; holder.set(value)");
         Assert.assertEquals(list1stElement, holder.get());
+    }
+
+
+    @Test
+    public void resultingV8Object_Of_OverriddenJavaInstanceInjection_ShouldHas_Fresh_ContentWhenReadBackInJava() {
+        final V8JavaClassInterceptor interceptor = new V8JavaClassInterceptor<Map>() {
+            @Override
+            public Object objectInjectorOverride(Map object) {
+                return V8ObjectUtils.toV8Object(v8, object);
+            }
+
+            @Override public String getConstructorScriptBody() { return null; }
+            @Override public void onInject(V8JavaClassInterceptorContext context, Map object) { }
+            @Override public void onExtract(V8JavaClassInterceptorContext context, Map object) { }
+        };
+
+
+        V8JavaAdapter.injectClass(HashMap.class, interceptor, v8);
+
+        final Map<String, Object> mapToExportToJs = new HashMap<String, Object>();
+
+        final String stringKey = "stringKey";
+        final String stringValue = "stringValue";
+        final String newStringValue = "stringValueNew";
+        mapToExportToJs.put(stringKey, stringValue);
+
+        final RawMapHolder mapProvider = new RawMapHolder();
+        mapProvider.setMap(mapToExportToJs);
+
+        final String mapProviderJsName = "mapProvider";
+        V8JavaAdapter.injectObject(mapProviderJsName, mapProvider, v8);
+
+        final String holderJsName = "holder";
+        AtomicReference<Object> holder = new AtomicReference<Object>();
+        V8JavaAdapter.injectObject(holderJsName, holder, v8);
+
+        v8.executeVoidScript("var exportedMap = mapProvider.getMap(); exportedMap['" + stringKey + "'] = '" + newStringValue + "'; holder.set(exportedMap)");
+        final Map mapReadBackFromV8Object = (Map) holder.get();
+        Assert.assertNotEquals(mapToExportToJs, mapReadBackFromV8Object);
+        Assert.assertEquals(newStringValue, mapReadBackFromV8Object.get("stringKey"));
     }
 }


### PR DESCRIPTION
if this v8 object is result of overridden java object injection in JS:
 do not attach resulting self-contained V8 object of overridden java object injection back to original java object.