### PR TITLE
added fix for static method calls with params.

### DIFF
--- a/src/main/java/io/alicorn/v8/V8JavaStaticMethodProxy.java
+++ b/src/main/java/io/alicorn/v8/V8JavaStaticMethodProxy.java
@@ -42,7 +42,7 @@ class V8JavaStaticMethodProxy extends V8JavaMethodProxy implements JavaCallback 
 
         //Invoke the method.
         try {
-            return V8JavaObjectUtils.translateJavaArgumentToJavascript(coercedMethod.invoke(coercedArguments), V8JavaObjectUtils.getRuntimeSarcastically(receiver), cache);
+            return V8JavaObjectUtils.translateJavaArgumentToJavascript(coercedMethod.invoke(null,coercedArguments), V8JavaObjectUtils.getRuntimeSarcastically(receiver), cache);
         } catch (IllegalAccessException e) {
             throw new IllegalArgumentException("Method received invalid arguments!");
         } catch (InvocationTargetException e) {

--- a/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
+++ b/src/test/java/io/alicorn/v8/V8JavaAdapterTest.java
@@ -13,6 +13,7 @@ import org.junit.*;
 import org.junit.rules.ExpectedException;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1026,5 +1027,20 @@ public class V8JavaAdapterTest {
         final Map mapReadBackFromV8Object = (Map) holder.get();
         Assert.assertNotEquals(mapToExportToJs, mapReadBackFromV8Object);
         Assert.assertEquals(newStringValue, mapReadBackFromV8Object.get("stringKey"));
+    }
+    @Test
+    public void shouldRunStaticMethodWithParams() {
+    	//build a random string for test
+    	String generatedString = "Hellow World";
+    	
+    	V8JavaAdapter.injectClass("StaticClass",StaticClass.class, v8);
+    	v8.executeScript("function shouldRunStaticMethodWithParams(param){return StaticClass.paramsReturn(param);}");
+    	v8.executeJSFunction("shouldRunStaticMethodWithParams", generatedString);
+    	Assert.assertEquals(generatedString, v8.executeJSFunction("shouldRunStaticMethodWithParams", generatedString));
+    }
+    static class StaticClass{
+    	public static <T> T paramsReturn(T obj) {
+    		return obj;
+    	}
     }
 }


### PR DESCRIPTION
I believe this will fix an issue with v8 javascript calling static methods with parameters.
 null on line 45 WILL send a null reference. an object(even if its a null reference) is expected for parameter 0 and the following parameters are objects passed to the method call. 